### PR TITLE
Fix cellular connectivity and add bluetooth connectivity to start-up script

### DIFF
--- a/wittypi/afterStartup.sh
+++ b/wittypi/afterStartup.sh
@@ -9,7 +9,8 @@
 #
 
 #Send telemtry beacon
-sudo python3 /home/pi/ami_setup-cellular-dev/ami-trap-raspi-cellular-send_and_receive.py >> /home/pi/wittypi/telemetry.log &
+sudo python3 /home/pi/ami_setup-cellular-dev/ami-trap-raspi-cellular.py >> /home/pi/wittypi/telemetry.log &
+sudo python3 /home/pi/ami_setup-bluetooth-dev/ami-trap-raspi-bluetooth.py >> /home/pi/wittypi/bluetooth.log &
 
 #Start motion software
 #sudo /usr/bin/motion -m


### PR DESCRIPTION
Edit the `afterStartup.sh` script:
* Run cellular connectivity not only at start-up, but every 6 h.
* Add Bluetooth connectivity.
@abhimandela Before merging, can you check that neither of the two commands is in `/etc/rc.local` already. They should either be in `/etc/rc.local` or in `afterStartup.sh`, but not in both. If they are already in `/etc/rc.local`, then there is no reason to merge.
Addressing issue https://github.com/AMI-system/ami_setup/issues/13